### PR TITLE
Ask LibGDX to make reflection data - fixes HTML version

### DIFF
--- a/core/src/SuperJumper.gwt.xml
+++ b/core/src/SuperJumper.gwt.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
 <module>
 	<source path="com/siondream/superjumper" />
+
+	<extend-configuration-property name="gdx.reflect.include" value="com.siondream.superjumper.components" />
+	<extend-configuration-property name="gdx.reflect.include" value="com.siondream.superjumper.systems" />
 </module>


### PR DESCRIPTION
For HTML builds, GWT doesn't implement reflection, which Ashley uses lots of. LibGDX has a workaround for this but you need to specifically tell it to (as done here).
